### PR TITLE
Removed sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
     - MOLECULEW_ANSIBLE=2.7.14
     - MOLECULEW_ANSIBLE=2.9.0
 
-# Require the standard build environment
-sudo: required
-
 # Require Ubuntu 14.04
 dist: trusty
 


### PR DESCRIPTION
The key `sudo` has no effect anymore.