### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Requirements
 
 * Ubuntu
 
-    * Xenial (16.04)
     * Bionic (18.04)
     * Focal (20.04)
     * Note: other Ubuntu versions may work but have not been tested.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
   galaxy_tags:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-lazygit-ubuntu-min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
   - name: ansible-role-lazygit-ubuntu-max
     image: ubuntu:20.04
 


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.